### PR TITLE
Add Bogotá localidades map example

### DIFF
--- a/bogota_localidades.html
+++ b/bogota_localidades.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Bogota Localidades Map</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+    integrity="sha256-p1AAAAFFGQCdZxOYhw3LrrxLiZt0pnfxLUNI0CtkbVY=" crossorigin=""/>
+  <style>
+    #map { height: 100vh; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+    integrity="sha256-oHi64UlAeUe1DGn/T9a5gYdhBY4Q4iIG65P1W+ZniD8=" crossorigin=""></script>
+  <script>
+    var map = L.map('map').setView([4.6482837, -74.2478936], 10);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      maxZoom: 18,
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+
+    fetch('https://raw.githubusercontent.com/codeforamerica/click_that_hood/master/public/data/bogota.geojson')
+      .then(function(response) { return response.json(); })
+      .then(function(geojson) {
+        L.geoJSON(geojson, {
+          onEachFeature: function(feature, layer) {
+            if (feature.properties && feature.properties.name) {
+              layer.on('click', function() {
+                layer.bindPopup(feature.properties.name).openPopup();
+              });
+            }
+            layer.setStyle({ color: '#3388ff', weight: 2, fillOpacity: 0.2 });
+            layer.on('mouseover', function() { this.setStyle({ fillOpacity: 0.6 }); });
+            layer.on('mouseout', function() { this.setStyle({ fillOpacity: 0.2 }); });
+          }
+        }).addTo(map);
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new HTML page with a Leaflet map

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684395c2a7d88324a304935e746022cc